### PR TITLE
fix: recognize low-fee flipstarter transactions

### DIFF
--- a/routes/baseActionsRouter.js
+++ b/routes/baseActionsRouter.js
@@ -805,9 +805,10 @@ function parseTwoOptionVote(tx) {
  */
 function isFlipstarter(tx, fee) {
   try {
-    if (fee < 3.9 || fee > 4.1) {
+    if (fee > 4.1) {
       return false;
     }
+
     if (tx.vin[0].coinbase) {
       return false;
     }


### PR DESCRIPTION
recognize low fee flipstarter transactions (ex: flipstarter.me, https://explorer.bitcoinunlimited.info/tx/f8f4fa31ab8e4b896c315cf56d84ea553404262830ac3ca4f38ae39c415c1d7a)